### PR TITLE
[gsoc] support open/save/copy/paste/new actions in gr-web

### DIFF
--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -1,0 +1,18 @@
+name: Build ubuntu:base image
+on: push
+jobs:
+ build:
+  name: Build Project
+  runs-on: ubuntu-20.04
+  steps:
+  - uses: actions/checkout@v3
+  - name: Checkout code and publish from make
+    working-directory: ./gnuradio
+    run: make base
+  - name: Publish to Docker Hub
+    uses: docker/build-push-action@v3
+    with:
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      repository: eat4toast/base
+      tags: latest, ${{ github.run_number }}

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -16,7 +16,4 @@ jobs:
       username: ${{ secrets.DOCKER_USERNAME }}
       password: ${{ secrets.DOCKER_PASSWORD }}
   - name: Publish to Docker Hub
-    uses: docker/build-push-action@v3
-    with:
-        push: true
-        tags: eat4toast/build-base:dev
+    run: docker push eat4toast/build-base:dev

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -7,7 +7,6 @@ jobs:
   steps:
   - uses: actions/checkout@v3
   - name: Checkout code and publish from make
-    working-directory: ./gnuradio
     run: make base
   - name: Publish to Docker Hub
     uses: docker/build-push-action@v3

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -9,7 +9,7 @@ jobs:
   - name: Checkout code and Build image
     run: | 
       make base
-      docker tag build-base:dev ${{ secrets.DOCKERHUB_USERNAME }}/build-base:dev
+      docker tag build-base:dev eat4toast/build-base:dev
   - name: Login to DockerHub
     uses: docker/login-action@v2
     with:

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -1,17 +1,22 @@
 name: Build ubuntu:base image
 on: push
 jobs:
- build:
+ build-project:
   name: Build Project
   runs-on: ubuntu-20.04
   steps:
   - uses: actions/checkout@v3
-  - name: Checkout code and publish from make
-    run: make base
+  - name: Checkout code and Build image
+    run: | 
+      make base
+      docker tag build-base:dev ${{ secrets.DOCKERHUB_USERNAME }}/build-base:dev
+  - name: Login to DockerHub
+    uses: docker/login-action@v2
+    with:
+      username: ${{ secrets.DOCKERHUB_USERNAME }}
+      password: ${{ secrets.DOCKERHUB_TOKEN }}
   - name: Publish to Docker Hub
     uses: docker/build-push-action@v3
     with:
-      username: ${{ secrets.DOCKERHUB_USERNAME }}
-      password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      repository: eat4toast/base
-      tags: latest, ${{ github.run_number }}
+        push: true
+        tags: eat4toast/build-base:dev

--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -13,8 +13,8 @@ jobs:
   - name: Login to DockerHub
     uses: docker/login-action@v2
     with:
-      username: ${{ secrets.DOCKERHUB_USERNAME }}
-      password: ${{ secrets.DOCKERHUB_TOKEN }}
+      username: ${{ secrets.DOCKER_USERNAME }}
+      password: ${{ secrets.DOCKER_PASSWORD }}
   - name: Publish to Docker Hub
     uses: docker/build-push-action@v3
     with:

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -13,8 +13,8 @@ jobs:
       cd emsdk 
       ./emsdk install 3.1.1
       ./emsdk activate 3.1.1
-      mkdir -p /usr/lib/
-      cp -r ./upstream/emscripten /usr/lib/
+      source "/home/runner/work/gnuradio-web/gnuradio-web/emsdk/emsdk_env.sh"
+      echo $$EMSDK
       cd ..
       
       docker pull eat4toast/build-base:dev 		# step1: pull build-base:dev image from docker hub

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -9,16 +9,14 @@ jobs:
   - uses: actions/checkout@v3
   - name: Checkout code and Build image
     run: | 
-      echo "{EMSDK_VER}={3.1.1}" >> $GITHUB_ENV 	# step0: prepare some dependency package
-      git clone --branch=${{ env.EMSDK_VER }} --depth=1 https://github.com/emscripten-core/emsdk.git 
+      git clone --branch=3.1.1 --depth=1 https://github.com/emscripten-core/emsdk.git 
       cd emsdk 
-      ./emsdk install ${{ env.EMSDK_VER }}
-      ./emsdk activate ${{ env.EMSDK_VER }}
-      cd ./upstream/ #  source emsdk_env.sh
+      ./emsdk install 3.1.1
+      ./emsdk activate 3.1.1
       mkdir -p /usr/lib/
-      cp -r emscripten /usr/lib/
-      cd ../..
-
+      cp -r ./upstream/emscripten /usr/lib/
+      cd ..
+      
       docker pull eat4toast/build-base:dev 		# step1: pull build-base:dev image from docker hub
       docker tag eat4toast/build-base:dev build-base:dev
       

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -14,13 +14,15 @@ jobs:
       ./emsdk install 3.1.1
       ./emsdk activate 3.1.1
       source "/home/runner/work/gnuradio-web/gnuradio-web/emsdk/emsdk_env.sh"
-      echo $$EMSDK
-      cd ..
+
+      cd ../
       
-      docker pull eat4toast/build-base:dev 		# step1: pull build-base:dev image from docker hub
+      git clone --branch=patch-2 --depth=1 https://github.com/haakov/gnuradio-web.git haakov_gnuradio
+      cd haakov_gnuradio
+      sed -i 's/\/usr\/lib\//\/home\/runner\/work\/gnuradio-web\/gnuradio-web\/emsdk\/upstream\//g' Makefile
+      
+      docker pull eat4toast/build-base:dev 		
       docker tag eat4toast/build-base:dev build-base:dev
       
-      # step2: here we temporary using Håkon's patch in gr-web building
-      git clone --branch=patch-2 --depth=1 https://github.com/haakov/gnuradio-web.git 
-      cd haakov_gnuradio
+
       make webapp

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -24,5 +24,5 @@ jobs:
       docker pull eat4toast/build-base:dev 		
       docker tag eat4toast/build-base:dev build-base:dev
       
-
+      make cpython
       make webapp

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -1,0 +1,28 @@
+name: Build ubuntu:base image
+on: push
+jobs:
+ build-project:
+  name: Build Project
+  runs-on: ubuntu-20.04
+  steps:
+  - uses: actions/checkout@v3
+  - name: Checkout code and Build image
+    run: | 
+# step0: prepare some dependency package
+      echo "{EMSDK_VER}={3.1.1}" >> $GITHUB_ENV
+      git clone --branch=${{ env.EMSDK_VER }} --depth=1 https://github.com/emscripten-core/emsdk.git 
+      cd emsdk 
+      ./emsdk install ${{ env.EMSDK_VER }}
+      ./emsdk activate ${{ env.EMSDK_VER }}
+      cd ./upstream/ #  source emsdk_env.sh
+      mkdir -p /usr/lib/
+      cp -r emscripten /usr/lib/
+      cd ../..
+# step1: pull build-base:dev image from docker hub
+      docker pull eat4toast/build-base:dev
+      docker tag eat4toast/build-base:dev build-base:dev
+      
+# step2: here we temporary using Håkon's patch in gr-web building
+      git clone --branch=patch-2 --depth=1 https://github.com/haakov/gnuradio-web.git
+      cd haakov_gnuradio
+      make webapp

--- a/.github/workflows/directly-build-webapp.yml
+++ b/.github/workflows/directly-build-webapp.yml
@@ -1,3 +1,4 @@
+
 name: Build ubuntu:base image
 on: push
 jobs:
@@ -8,8 +9,7 @@ jobs:
   - uses: actions/checkout@v3
   - name: Checkout code and Build image
     run: | 
-# step0: prepare some dependency package
-      echo "{EMSDK_VER}={3.1.1}" >> $GITHUB_ENV
+      echo "{EMSDK_VER}={3.1.1}" >> $GITHUB_ENV 	# step0: prepare some dependency package
       git clone --branch=${{ env.EMSDK_VER }} --depth=1 https://github.com/emscripten-core/emsdk.git 
       cd emsdk 
       ./emsdk install ${{ env.EMSDK_VER }}
@@ -18,11 +18,11 @@ jobs:
       mkdir -p /usr/lib/
       cp -r emscripten /usr/lib/
       cd ../..
-# step1: pull build-base:dev image from docker hub
-      docker pull eat4toast/build-base:dev
+
+      docker pull eat4toast/build-base:dev 		# step1: pull build-base:dev image from docker hub
       docker tag eat4toast/build-base:dev build-base:dev
       
-# step2: here we temporary using Håkon's patch in gr-web building
-      git clone --branch=patch-2 --depth=1 https://github.com/haakov/gnuradio-web.git
+      # step2: here we temporary using Håkon's patch in gr-web building
+      git clone --branch=patch-2 --depth=1 https://github.com/haakov/gnuradio-web.git 
       cd haakov_gnuradio
       make webapp

--- a/grc-dev/gnuradio/grc/gui_qt/components/flowgraph.py
+++ b/grc-dev/gnuradio/grc/gui_qt/components/flowgraph.py
@@ -316,6 +316,88 @@ class Flowgraph(QtWidgets.QGraphicsScene, base.Component, CoreFlowgraph):
         self.removeItem(element)
         super(Flowgraph, self).remove_element(element)
 
+    # Below `copy` and `paste` locates as a copy from grc/gui/canvas/flowgprah.py
+    # def copy_to_clipboard(self):
+    #     # get selected blocks
+    #     blocks = list(self.selected_blocks())
+    #     if not blocks:
+    #         return None
+    #     # calc x and y min
+    #     x_min, y_min = blocks[0].coordinate
+    #     for block in blocks:
+    #         x, y = block.coordinate
+    #         x_min = min(x, x_min)
+    #         y_min = min(y, y_min)
+    #     # get connections between selected blocks
+    #     connections = list(filter(
+    #         lambda c: c.source_block in blocks and c.sink_block in blocks,
+    #         self.connections,
+    #     ))
+    #     clipboard = (
+    #         (x_min, y_min),
+    #         [block.export_data() for block in blocks],
+    #         [connection.export_data() for connection in connections],
+    #     )
+    #     return clipboard
+
+    # def paste_from_clipboard(self, clipboard):
+    #     """
+    #     Paste the blocks and connections from the clipboard.
+
+    #     Args:
+    #         clipboard: the nested data of blocks, connections
+    #     """
+    #     (x_min, y_min), blocks_n, connections_n = clipboard
+    #     # recalc the position
+    #     scroll_pane = self.drawing_area.get_parent().get_parent()
+    #     h_adj = scroll_pane.get_hadjustment()
+    #     v_adj = scroll_pane.get_vadjustment()
+    #     x_off = h_adj.get_value() - x_min + h_adj.get_page_size() / 4
+    #     y_off = v_adj.get_value() - y_min + v_adj.get_page_size() / 4
+
+    #     if len(self.get_elements()) <= 1:
+    #         x_off, y_off = 0, 0
+
+    #     # create blocks
+    #     pasted_blocks = {}
+    #     for block_n in blocks_n:
+    #         block_key = block_n.get('id')
+    #         if block_key == 'options':
+    #             continue
+
+    #         block_name = block_n.get('name')
+    #         # Verify whether a block with this name exists before adding it
+    #         if block_name in (blk.name for blk in self.blocks):
+    #             block_n = block_n.copy()
+    #             block_n['name'] = self._get_unique_id(block_name)
+
+    #         block = self.new_block(block_key)
+    #         if not block:
+    #             continue  # unknown block was pasted (e.g. dummy block)
+
+    #         block.import_data(**block_n)
+    #         pasted_blocks[block_name] = block  # that is before any rename
+
+    #         block.move((x_off, y_off))
+    #         while any(Utils.align_to_grid(block.coordinate) == Utils.align_to_grid(other.coordinate)
+    #                   for other in self.blocks if other is not block):
+    #             block.move((Constants.CANVAS_GRID_SIZE,
+    #                        Constants.CANVAS_GRID_SIZE))
+    #             # shift all following blocks
+    #             x_off += Constants.CANVAS_GRID_SIZE
+    #             y_off += Constants.CANVAS_GRID_SIZE
+
+    #     self.selected_elements = set(pasted_blocks.values())
+
+    #     # update before creating connections
+    #     self.update()
+    #     # create connections
+    #     for src_block, src_port, dst_block, dst_port in connections_n:
+    #         source = pasted_blocks[src_block].get_source(src_port)
+    #         sink = pasted_blocks[dst_block].get_sink(dst_port)
+    #         connection = self.connect(source, sink)
+    #         self.selected_elements.add(connection)
+
 
 class FlowgraphView(QtWidgets.QGraphicsView, base.Component): # added base.Component so it can see platform
     def __init__(self, parent, filename=None):


### PR DESCRIPTION
This **draft pr** intend to support  open/save/copy/paste/new actions in gnuradio-web
**those contexts are still WIP since there are some weird interactions with emscripten virtual file system API.**

refer to `open and save`. The logic is really straightforward: 

#### for open: 

* Get the file path and import the data
* trans the data to flowgraph
* update flow graph

#### for save or save as

* Get the saved name
* export the data to the YAML file under the specific path name


I failed with the directly logging to ensure whether they are called correctly to get the file path/name, which means the official `QFileDialog.getOpenFileName` does not work well. (Sad)

#### for copy and paste:
Since the upstream qt_gui in gnuradio has not implemented the `copy and paste` full feature, I try to call the origin flowgraph::copy/paste related method, with the flowgraph update. But seems there lack of some block connections with the transplant of the` copy` && `paste`.
#### for new:
it will new flow graph and set the newer one to central.

